### PR TITLE
Fix for crontab job fail.

### DIFF
--- a/adaway-linux.sh
+++ b/adaway-linux.sh
@@ -72,7 +72,7 @@ while read src; do
     else
         echo "[i] skipping $src"
     fi
-done <hostssources.lst
+done < $(dirname $0)/hostssources.lst
 
 uniq <(sort "${TMPDIR}hosts.downloaded") > "${TMPDIR}hosts.adservers"
 


### PR DESCRIPTION
Fix for the while loop. It was not able to read "hostssources.lst" if the script was not being executed from its residing folder.

/root/adaway-linux/adaway-linux.sh: line 76: hostssources.lst: No such file or directory
sort: cannot read: /tmp/adaway-linux/hosts.downloaded: No such file or directory