### PR TITLE
ADDED: Systemd as weekly scheduler, using wget as fallback if curl should fail

### DIFF
--- a/adaway-linux.sh
+++ b/adaway-linux.sh
@@ -61,7 +61,9 @@ while read src; do
         # - remove additional localhost entries possibly picked up from sources
         # - remove remaining comments
         # - split all entries with one tab
-wget  "${src}"  -nv --show-progress -L -O - \
+        #which curl;
+        if type curl 2>/dev/null > /dev/null; then
+          curl --progress-bar -L "${src}" \
             | sed 's/\r/\n/' \
             | sed 's/^\s\+//' \
             | sed 's/^127\.0\.0\.1/0.0.0.0/' \
@@ -69,12 +71,22 @@ wget  "${src}"  -nv --show-progress -L -O - \
             | grep -v '\slocalhost\s*' \
             | sed 's/\s*\#.*//g' \
             | sed 's/\s\+/\t/g' \
-            >> "${TMPDIR}hosts.downloaded"
-    else
+            >> "${TMPDIR}hosts.downloaded";
+        else
+          wget  "${src}" -nv --show-progress -L -O - \
+            | sed 's/\r/\n/' \
+            | sed 's/^\s\+//' \
+            | sed 's/^127\.0\.0\.1/0.0.0.0/' \
+            | grep '^0\.0\.0\.0' \
+            | grep -v '\slocalhost\s*' \
+            | sed 's/\s*\#.*//g' \
+            | sed 's/\s\+/\t/g' \
+            >> "${TMPDIR}hosts.downloaded";
+        fi
+      else
         echo "[i] skipping $src"
     fi
 done < $DIR/hostssources.lst
-
 uniq <(sort "${TMPDIR}hosts.downloaded") > "${TMPDIR}hosts.adservers"
 
 # fists lines of /etc/hosts

--- a/adaway-linux.sh
+++ b/adaway-linux.sh
@@ -61,7 +61,6 @@ while read src; do
         # - remove additional localhost entries possibly picked up from sources
         # - remove remaining comments
         # - split all entries with one tab
-        #which curl;
         if type curl 2>/dev/null > /dev/null; then
           curl --progress-bar -L "${src}" \
             | sed 's/\r/\n/' \

--- a/adaway-linux.sh
+++ b/adaway-linux.sh
@@ -4,7 +4,7 @@
 # Remove ads system-wide in Linux                           #
 #############################################################
 # authors:  sedrubal, diy-electronics                       #
-# version:  v3.0                                            #
+# version:  v3.1                                            #
 # licence:  CC BY-SA 4.0                                    #
 # github:   https://github.com/sedrubal/adaway-linux        #
 #############################################################
@@ -12,6 +12,7 @@
 # settings
 HOSTSORIG="/etc/.hosts.original"
 TMPDIR="/tmp/adaway-linux/"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # Gets the location of the script
 #
 
 set -e
@@ -60,7 +61,7 @@ while read src; do
         # - remove additional localhost entries possibly picked up from sources
         # - remove remaining comments
         # - split all entries with one tab
-        curl --progress-bar -L "${src}" \
+wget  "${src}"  -nv --show-progress -L -O - \
             | sed 's/\r/\n/' \
             | sed 's/^\s\+//' \
             | sed 's/^127\.0\.0\.1/0.0.0.0/' \
@@ -72,7 +73,7 @@ while read src; do
     else
         echo "[i] skipping $src"
     fi
-done < $(dirname $0)/hostssources.lst
+done < $DIR/hostssources.lst
 
 uniq <(sort "${TMPDIR}hosts.downloaded") > "${TMPDIR}hosts.adservers"
 

--- a/install.sh
+++ b/install.sh
@@ -4,15 +4,16 @@
 # Remove ads system-wide in Linux                         #
 ###########################################################
 # authors:      sedrubal, diy-electronics                 #
-# version:      v3.0                                      #
+# version:      v3.1                                      #
 # licence:      CC BY-SA 4.0                              #
 # github:       https://github.com/sedrubal/adaway-linux  #
 ###########################################################
 
 # settings
 HOSTS_ORIG="/etc/.hosts.original"
-SRCLST="hostssources.lst"
-VERSION="3.0"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # Gets the location of the script
+SRCLST="$DIR/hostssources.lst"
+VERSION="3.1"
 #
 
 set -e

--- a/install.sh
+++ b/install.sh
@@ -4,19 +4,27 @@
 # Remove ads system-wide in Linux                         #
 ###########################################################
 # authors:      sedrubal, diy-electronics                 #
-# version:      v3.1                                      #
+# version:      v3.2                                      #
 # licence:      CC BY-SA 4.0                              #
 # github:       https://github.com/sedrubal/adaway-linux  #
 ###########################################################
 
 # settings
 HOSTS_ORIG="/etc/.hosts.original"
+SYSTEMD_DIR="/etc/systemd/system"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # Gets the location of the script
 SRCLST="$DIR/hostssources.lst"
-VERSION="3.1"
+VERSION="3.2"
 #
 
+
 set -e
+
+# check root
+if [ "$(id -u)" != "0" ] ; then
+    echo "This script must be run as root" 1>&2
+    exit 1
+fi
 
 case "${1}" in
     "-u" | "--uninstall" )
@@ -24,13 +32,22 @@ case "${1}" in
         read -r -p "[?] Do you really want to uninstall adaway-linux and restore the original /etc/hosts? [Y/n] " REPLY
         case "${REPLY}" in
             "YES" | "Yes" | "yes" | "Y" | "y" | "" )
+                if [ -e ${SYSTEMD_DIR}/adaway-linux.timer ] || [ -e ${SYSTEMD_DIR}/adaway-linux.service ] ; then
+                  echo "[!] Removing services..."
+                  # Unhooking the systemd service
+                  systemctl disable adaway-linux.service || echo "[!] adaway-linux.service is missing. Have you removed it?"
+                  systemctl disable adaway-linux.timer || echo "[!] adaway-linux.timer is missing. Have you removed it?"
+                  rm ${SYSTEMD_DIR}/adaway-linux.*
+                else
+                  echo "[i] No adaway service installed. Skipping.."
+                fi
                 echo "[i] Restoring /etc/hosts"
-                sudo mv "${HOSTS_ORIG}" /etc/hosts
-                echo "[!] If you added a cronjob, please remove it yourself."
+                mv "${HOSTS_ORIG}" /etc/hosts || echo "[!] Couldn't restore original hosts file."
+
                 echo "[i] finished"
                 exit 0
                 ;;
-            "NO" | "No" | "no" | "N" | "n" )
+            * | "NO" | "No" | "no" | "N" | "n" )
                 echo "[i] cancelled"
                 exit 1
                 ;;
@@ -48,7 +65,7 @@ case "${1}" in
                 if [ "$2" != "-f" ] && [ "$ARG1" != "--force" ] ; then
                     # backup /etc/hosts
                     echo "[i] First I will backup the original /etc/hosts to ${HOSTS_ORIG}."
-                    sudo cp /etc/hosts "${HOSTS_ORIG}"
+                    cp /etc/hosts "${HOSTS_ORIG}"
                     # check if backup was succesfully
                     if [ ! -e "${HOSTS_ORIG}" ] ; then
                         echo "[!] Backup of /etc/hosts failed. Please backup this file manually and bypass this check by using the -f parameter."
@@ -66,23 +83,49 @@ https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimet
 EOF
                 echo "[i] File created."
 
-                # add cronjob
-                read -r -p "[?] Create a cronjob which updates /etc/hosts with new adservers every 5 days? [Y/n] " REPLY
+                # add systemd service
+                read -r -p "[?] Create a systemd service which updates /etc/hosts with new adservers every week? [Y/n] " REPLY
                 case "${REPLY}" in
                     "YES" | "Yes" | "yes" | "Y" | "y" | "" )
-                        echo "[i] Creating cronjob..."
-                        line="1 12 */5 * * ${PWD}/adaway-linux.sh"
-                        (sudo crontab -u root -l; echo "$line" ) | sudo crontab -u root -
+                        echo "[i] Creating service..."
+
+                        # create .service file
+                        cat > "${SYSTEMD_DIR}/adaway-linux.service" <<EOL
+[Unit]
+Description=Service to run adaway-linux weekly
+
+[Service]
+ExecStart=$DIR/adaway-linux.sh
+EOL
+
+                        # create .timer file
+                        cat > "${SYSTEMD_DIR}/adaway-linux.timer" <<EOL
+[Unit]
+Description=Run adaway-linux weekly
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+Unit=adaway-linux.service
+
+[Install]
+WantedBy=timers.target
+EOL
+                        chmod 755 ${SYSTEMD_DIR}/adaway-linux.*
+
+                        # Enable the schedule
+                        systemctl enable adaway-linux.timer && echo "[i] Service succesfully installed."
+
                         ;;
-                    "NO" | "No" | "no" | "N" | "n" )
-                        echo "[i] No cronjob created."
+                      * | "NO" | "No" | "no" | "N" | "n" )
+                        echo "[i] No service created."
                         ;;
                 esac
 
                 echo "[i] finished. For uninstall, please run ${0} -u"
                 exit 0
                 ;;
-            "NO" | "No" | "no" | "N" | "n" )
+            * | "NO" | "No" | "no" | "N" | "n" )
                 echo "[i] cancelled"
                 exit 1
                 ;;

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,8 @@ case "${1}" in
                 if [ -e ${SYSTEMD_DIR}/adaway-linux.timer ] || [ -e ${SYSTEMD_DIR}/adaway-linux.service ] ; then
                   echo "[!] Removing services..."
                   # Unhooking the systemd service
+                  systemctl stop adaway-linux.service
+                  systemctl stop adaway-linux.timer
                   systemctl disable adaway-linux.service || echo "[!] adaway-linux.service is missing. Have you removed it?"
                   systemctl disable adaway-linux.timer || echo "[!] adaway-linux.timer is missing. Have you removed it?"
                   rm ${SYSTEMD_DIR}/adaway-linux.*
@@ -114,7 +116,8 @@ EOL
                         chmod 755 ${SYSTEMD_DIR}/adaway-linux.*
 
                         # Enable the schedule
-                        systemctl enable adaway-linux.timer && echo "[i] Service succesfully installed."
+                        systemctl enable adaway-linux.timer
+                        systemctl start adaway-linux.timer && echo "[i] Service succesfully initialized."
 
                         ;;
                       * | "NO" | "No" | "no" | "N" | "n" )


### PR DESCRIPTION
Replaced curl with wget for the reason that it's not shipped on some distros by default any more.
Also fixed an issue when called the script remotely the hostssources.lst file is not saved to the scripts directory, instead is was saved where the script has been remotely executed from.