### PR TITLE
Fixed issue where the hostssources.lst file is created at the 

### DIFF
--- a/adaway-linux.sh
+++ b/adaway-linux.sh
@@ -14,6 +14,8 @@ HOSTSORIG="/etc/.hosts.original"
 TMPDIR="/tmp/adaway-linux/"
 #
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # Gets the location of the script
+
 set -e
 
 # show help
@@ -72,7 +74,7 @@ while read src; do
     else
         echo "[i] skipping $src"
     fi
-done < $(dirname $0)/hostssources.lst
+done < $DIR/hostssources.lst
 
 uniq <(sort "${TMPDIR}hosts.downloaded") > "${TMPDIR}hosts.adservers"
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,8 @@
 
 # settings
 HOSTS_ORIG="/etc/.hosts.original"
-SRCLST="hostssources.lst"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # Gets the location of the script
+SRCLST="$DIR/hostssources.lst"
 VERSION="3.0"
 #
 


### PR DESCRIPTION
Fixed issue where the hostssources.lst file is created at the execution source and not at the location of the script.

For instance we execute `install.sh` remotely and using the option to create a cronjob. The `hostssources.lst` file will be created somewhere but not in the scripts directory. Now the cronjob will fail caused by the missing  `hostssources.lst` file because it doesn't know where to look for it.